### PR TITLE
Fix tests for move rock

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -101,7 +101,10 @@ describe('Rock Dodger', () => {
 
       it('removes the rock once it falls of the screen', done => {
         window.requestAnimationFrame = cb => {
-          setInterval(cb, 0)
+          return setTimeout(cb, 0)
+        }
+        window.cancelAnimationFrame = id => {
+          return clearTimeout(id)
         }
 
         const rock = createRock(2)
@@ -112,7 +115,7 @@ describe('Rock Dodger', () => {
         setTimeout(() => {
           expect(spy).toHaveBeenCalled()
           done()
-        }, 50)
+        }, 300)
       })
     })
   })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -92,10 +92,6 @@ describe('Rock Dodger', () => {
         const spy = expect.spyOn(window, 'endGame')
         const stub = expect.spyOn(window, 'checkCollision').andReturn(true)
 
-        window.requestAnimationFrame = cb => {
-          cb()
-        }
-
         createRock(182)
 
         expect(spy).toHaveBeenCalled()


### PR DESCRIPTION
See commit messages for details. These changes fix some issues related to mocked versions of window.requestAnimationFrame used in some tests of the moveRock function.

These changes were necessary to get tests passing for my version of the solution, found [here](https://github.com/bgrabow/javascript-rock-dodger-js-intro-000/commit/86ec6a4321613f82f62086b62a8c32f77e6eac8f). There may be other modifications to the tests necessary to make them work for other reasonable solutions.